### PR TITLE
Add platform helper for OS-specific executable selection

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace NullAI
         public MainWindow()
         {
             InitializeComponent();
+            Title = $"{Constants.ApplicationName} ({PlatformHelper.GetExecutableName()})";
             _apiKeyManager = new ApiKeyManager();
             _aiService = new AIService(_apiKeyManager);
             _speechService = new SpeechService();

--- a/Utilities/PlatformHelper.cs
+++ b/Utilities/PlatformHelper.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+
+namespace NullAI.Utilities
+{
+    /// <summary>
+    /// Provides helpers for detecting the current operating system and
+    /// returning appropriate executable names.
+    /// </summary>
+    public static class PlatformHelper
+    {
+        /// <summary>
+        /// Returns <c>true</c> when running on a Windows OS.
+        /// </summary>
+        public static bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when running on Ubuntu 24.04 LTS.
+        /// </summary>
+        public static bool IsUbuntuNoble()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return false;
+            }
+            var description = RuntimeInformation.OSDescription;
+            return description.Contains("Ubuntu", System.StringComparison.OrdinalIgnoreCase)
+                   && description.Contains("24.04");
+        }
+
+        /// <summary>
+        /// Gets the executable file name for the current platform.
+        /// </summary>
+        public static string GetExecutableName()
+        {
+            if (IsWindows())
+            {
+                return "NullAI.exe";
+            }
+            if (IsUbuntuNoble())
+            {
+                return "NullAI";
+            }
+            return "NullAI";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PlatformHelper` to detect Windows and Ubuntu 24.04 LTS
- show platform-specific executable name in MainWindow title

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6896fe0a376483288732af7d6465a460